### PR TITLE
feat: Dynamic Metrics

### DIFF
--- a/packages/lib/src/config/config.ts
+++ b/packages/lib/src/config/config.ts
@@ -1,7 +1,7 @@
 import merge from 'lodash.merge';
 import { OasTlmConfig, DeepPartial, UserConfig } from './config.types.js';
 import { BufferConfig, SpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-node';
-import { IMetricReader, MetricProducer } from '@opentelemetry/sdk-metrics';
+import { IMetricReader, MetricProducer, PushMetricExporter } from '@opentelemetry/sdk-metrics';
 import { LogRecordExporter, LogRecordProcessor } from '@opentelemetry/sdk-logs';
 import { type PluginResource } from '../types/index.js';
 import { type ViewOptions } from '@opentelemetry/sdk-metrics/build/src/view/View.js';
@@ -99,6 +99,7 @@ export const defaultConfig = {
         },
         extraReaders: [] as IMetricReader[], // e.g. [new PrometheusExporter()]
         extraViews: [] as ViewOptions[], // e.g. [new MetricView({ name: 'my_metric', labels: ['env'] })]
+        extraExporters: [] as PushMetricExporter[],
         memoryExporter: {
             enabled: true,
             retentionTimeSeconds: 60 * 60, // 1 hour

--- a/packages/lib/src/config/config.types.ts
+++ b/packages/lib/src/config/config.types.ts
@@ -1,5 +1,5 @@
 import { LogRecordExporter, LogRecordProcessor } from "@opentelemetry/sdk-logs";
-import { IMetricReader } from "@opentelemetry/sdk-metrics";
+import { IMetricReader, PushMetricExporter } from "@opentelemetry/sdk-metrics";
 import { SpanExporter, SpanProcessor } from "@opentelemetry/sdk-trace-node";
 import { defaultConfig } from "./config.js";
 import { ViewOptions } from "@opentelemetry/sdk-metrics/build/src/view/View.js";
@@ -31,6 +31,7 @@ export type UserConfig = {
     mainMetricReaderOptions?: Partial<OasTlmConfig["metrics"]["mainMetricReaderOptions"]>;
     extraReaders?: IMetricReader[];  // required shape
     extraViews?: ViewOptions[];
+    extraExporters?: PushMetricExporter[];
     memoryExporter?: Partial<OasTlmConfig["metrics"]["memoryExporter"]>;
   };
   logs?: {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -31,3 +31,5 @@ function oasTelemetry(oasTlmInputConfig?: UserConfig) {
 }
 
 export { oasTelemetry };
+export { DynamicPeriodicMetricReader } from './telemetry/custom-implementations/metrics/DynamicPeriodicMetricReader.js';
+export { FilterMetricExporter } from './telemetry/custom-implementations/exporters/FilterMetricExporter.js';

--- a/packages/lib/src/telemetry/custom-implementations/exporters/FilterMetricExporter.ts
+++ b/packages/lib/src/telemetry/custom-implementations/exporters/FilterMetricExporter.ts
@@ -1,0 +1,55 @@
+import { ExportResult } from '@opentelemetry/core';
+import { PushMetricExporter, ResourceMetrics } from '@opentelemetry/sdk-metrics';
+
+export class FilterMetricExporter implements PushMetricExporter {
+    private readonly exporter: PushMetricExporter;
+    private ignoredMetrics: Set<string> = new Set<string>();
+
+    constructor(exporter: PushMetricExporter) {
+        this.exporter = exporter;
+    }
+
+    addIgnoredMetric(metric: string): void {
+        this.ignoredMetrics.add(metric);
+    }
+
+    addIgnoredMetrics(metrics: string[]): void {
+        metrics.forEach((metric) => this.ignoredMetrics.add(metric));
+    }
+
+    removeIgnoredMetric(metric: string): void {
+        this.ignoredMetrics.delete(metric);
+    }
+
+    clearIgnoredMetrics(): void {
+        this.ignoredMetrics.clear();
+    }
+
+    getIgnoredMetrics(): string[] {
+        return Array.from(this.ignoredMetrics);
+    }
+
+    export(resourceMetrics: ResourceMetrics, resultCallback: (result: ExportResult) => void): void {
+        // Filter resourceMetrics.scopeMetrics based on scope.name
+        const filteredScopeMetrics = resourceMetrics.scopeMetrics.filter((scopeMetric) => {
+            const scopeName = scopeMetric.scope?.name;
+            return !scopeName || !this.ignoredMetrics.has(scopeName);
+        });
+
+        // We pass the filtered resourceMetrics down to the wrapped exporter.
+        const filteredResourceMetrics: ResourceMetrics = {
+            resource: resourceMetrics.resource,
+            scopeMetrics: filteredScopeMetrics
+        };
+
+        this.exporter.export(filteredResourceMetrics, resultCallback);
+    }
+
+    async shutdown(): Promise<void> {
+        await this.exporter.shutdown();
+    }
+
+    async forceFlush(): Promise<void> {
+        await this.exporter.forceFlush?.();
+    }
+}

--- a/packages/lib/src/telemetry/custom-implementations/metrics/DynamicPeriodicMetricReader.ts
+++ b/packages/lib/src/telemetry/custom-implementations/metrics/DynamicPeriodicMetricReader.ts
@@ -1,0 +1,124 @@
+import { MetricReader, PushMetricExporter, MetricProducer, ResourceMetrics } from '@opentelemetry/sdk-metrics';
+import { ExportResultCode, globalErrorHandler, internal } from '@opentelemetry/core';
+import { diag } from '@opentelemetry/api';
+
+export interface DynamicPeriodicMetricReaderOptions {
+    exporter: PushMetricExporter;
+    exportIntervalMillis?: number;
+    exportTimeoutMillis?: number;
+    metricProducers?: MetricProducer[];
+}
+
+export class DynamicPeriodicMetricReader extends MetricReader {
+    private _interval?: NodeJS.Timeout | number;
+    private _exporter: PushMetricExporter;
+    private _exportInterval: number;
+    private _exportTimeout: number;
+
+    constructor(options: DynamicPeriodicMetricReaderOptions) {
+        const { exporter, exportIntervalMillis = 60000, metricProducers } = options;
+        const exportTimeoutMillis = options.exportTimeoutMillis ?? 30000;
+        super({
+            aggregationSelector: exporter.selectAggregation?.bind(exporter),
+            aggregationTemporalitySelector: exporter.selectAggregationTemporality?.bind(exporter),
+            metricProducers,
+        });
+        if (exportIntervalMillis <= 0) {
+            throw new Error('exportIntervalMillis must be greater than 0');
+        }
+        if (exportTimeoutMillis <= 0) {
+            throw new Error('exportTimeoutMillis must be greater than 0');
+        }
+        this._exportInterval = exportIntervalMillis;
+        this._exportTimeout = exportTimeoutMillis;
+        this._exporter = exporter;
+    }
+
+    async _runOnce(): Promise<void> {
+        try {
+            // Promise-based timeout wrapper to mirror callWithTimeout
+            await Promise.race([
+                this._doRun(),
+                new Promise<void>((_, reject) =>
+                    setTimeout(() => reject(new Error('Timeout')), this._exportTimeout)
+                )
+            ]);
+        } catch (err: any) {
+            if (err.message === 'Timeout') {
+                diag.error(`Export took longer than ${this._exportTimeout} milliseconds and timed out.`);
+                return;
+            }
+            globalErrorHandler(err);
+        }
+    }
+
+    async _doRun(): Promise<void> {
+        const { resourceMetrics, errors } = await this.collect({
+            timeoutMillis: this._exportTimeout,
+        });
+        if (errors.length > 0) {
+            diag.error('DynamicPeriodicMetricReader: metrics collection errors', ...errors);
+        }
+        if (resourceMetrics.resource.asyncAttributesPending) {
+            try {
+                await resourceMetrics.resource.waitForAsyncAttributes?.();
+            } catch (e: any) {
+                diag.debug('Error while resolving async portion of resource: ', e);
+                globalErrorHandler(e);
+            }
+        }
+        if (resourceMetrics.scopeMetrics.length === 0) {
+            return;
+        }
+
+        // Use the official internal._export helper
+        const result = await internal._export(this._exporter, resourceMetrics);
+        if (result.code !== ExportResultCode.SUCCESS) {
+            throw new Error(`DynamicPeriodicMetricReader: metrics export failed (error ${result.error})`);
+        }
+    }
+
+    onInitialized(): void {
+        this._startTimer();
+    }
+
+    private _startTimer() {
+        this._stopTimer();
+        this._interval = setInterval(() => {
+            void this._runOnce();
+        }, this._exportInterval);
+        if (this._interval && typeof this._interval !== 'number') {
+            this._interval.unref();
+        }
+    }
+
+    private _stopTimer() {
+        if (this._interval) {
+            clearInterval(this._interval as any);
+            this._interval = undefined;
+        }
+    }
+
+    async onForceFlush(): Promise<void> {
+        await this._runOnce();
+        await this._exporter.forceFlush?.();
+    }
+
+    async onShutdown(): Promise<void> {
+        this._stopTimer();
+        await this.onForceFlush();
+        await this._exporter.shutdown();
+    }
+
+    getInterval(): number {
+        return this._exportInterval;
+    }
+
+    setInterval(exportIntervalMillis: number): void {
+        if (exportIntervalMillis <= 0) {
+            throw new Error('exportIntervalMillis must be greater than 0');
+        }
+        this._exportInterval = exportIntervalMillis;
+        this._startTimer();
+    }
+}

--- a/packages/lib/src/telemetry/telemetryConfigurator.ts
+++ b/packages/lib/src/telemetry/telemetryConfigurator.ts
@@ -4,12 +4,14 @@ import { SpanProcessor, BatchSpanProcessor as TraceBatchSpanProcessor, SimpleSpa
 import { OasTlmConfig } from '../config/config.types.js';
 import logger from '../utils/logger.js';
 import { EnablerMultiLogExporter, EnablerMultiSpanExporter } from './custom-implementations/wrappers.js';
-import { inMemoryDbLogExporter, inMemoryDbMetricExporter, inMemoryDbSpanExporter, instrumentations, multiLogExporter, multiSpanExporter, oasTelemetryResource } from './telemetryRegistry.js';
+import { inMemoryDbLogExporter, inMemoryDbMetricExporter, inMemoryDbSpanExporter, instrumentations, multiLogExporter, multiSpanExporter, oasTelemetryResource, setMainMetricReader, setCustomFilterMetricExporter } from './telemetryRegistry.js';
 
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { bootEnvVariables } from '../config/bootConfig.js';
 import { pluginService } from '../tlm-plugin/pluginService.js';
 import { MultiMetricExporter } from './custom-implementations/exporters/MultiMetricExporter.js';
+import { DynamicPeriodicMetricReader } from './custom-implementations/metrics/DynamicPeriodicMetricReader.js';
+import { FilterMetricExporter } from './custom-implementations/exporters/FilterMetricExporter.js';
 
 export function configureTelemetry(oasTlmConfig: OasTlmConfig) {
 
@@ -68,13 +70,20 @@ function configureMetrics(oasTlmConfig: OasTlmConfig) {
     // METRICS CONFIGURATION
     inMemoryDbMetricExporter.setEnabledValue(oasTlmConfig.metrics.memoryExporter.enabled);
     inMemoryDbMetricExporter.retentionTimeInSeconds = oasTlmConfig.metrics.memoryExporter.retentionTimeSeconds;
-    const metricExporters: PushMetricExporter[] = [inMemoryDbMetricExporter];
 
-    const mainReader = new PeriodicExportingMetricReader({
-        exporter: new MultiMetricExporter(metricExporters),
+    const userExporters = oasTlmConfig.metrics.extraExporters || [];
+    const userExportersMultiExporter = new MultiMetricExporter(userExporters);
+    const filterExporter = new FilterMetricExporter(userExportersMultiExporter);
+    setCustomFilterMetricExporter(filterExporter);
+
+    const mainExporter = new MultiMetricExporter([inMemoryDbMetricExporter, filterExporter]);
+
+    const mainReader = new DynamicPeriodicMetricReader({
+        exporter: mainExporter,
         exportIntervalMillis: oasTlmConfig.metrics.mainMetricReaderOptions.exportIntervalMillis,
         metricProducers: oasTlmConfig.metrics.mainMetricReaderOptions.metricProducers
     });
+    setMainMetricReader(mainReader);
     return mainReader;
 }
 

--- a/packages/lib/src/telemetry/telemetryRegistry.ts
+++ b/packages/lib/src/telemetry/telemetryRegistry.ts
@@ -8,6 +8,8 @@ import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { bootEnvVariables } from "../config/bootConfig.js";
 import { type Instrumentation } from "@opentelemetry/instrumentation";
+import { DynamicPeriodicMetricReader } from "./custom-implementations/metrics/DynamicPeriodicMetricReader.js";
+import { FilterMetricExporter } from "./custom-implementations/exporters/FilterMetricExporter.js";
 
 // GLOBAL REGISTRY of telemetry components, used by SDKs and controllers.
 let _bootInitialized = false;
@@ -58,10 +60,16 @@ export const originalConsoleMethods = {
 // Metrics follow a different pattern in OpenTelemetry
 
 export const inMemoryDbMetricExporter = new InMemoryDbMetricExporter();
+export let mainMetricReader: DynamicPeriodicMetricReader | undefined = undefined;
+export let customFilterMetricExporter: FilterMetricExporter | undefined = undefined;
 
+export function setMainMetricReader(reader: DynamicPeriodicMetricReader) {
+    mainMetricReader = reader;
+}
 
-// Readers and their exporters cannot be grouped together in a MultiReader or similar construct
-// due to differences in aggregation temporality and aggregation selection.
+export function setCustomFilterMetricExporter(exporter: FilterMetricExporter) {
+    customFilterMetricExporter = exporter;
+}
 
 // INSTRUMENTATIONS -----------------------------------------------------------------------
 

--- a/packages/lib/src/tlm-metric/metricsController.ts
+++ b/packages/lib/src/tlm-metric/metricsController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { inMemoryDbMetricExporter } from '../telemetry/telemetryRegistry.js';
+import { inMemoryDbMetricExporter, mainMetricReader, customFilterMetricExporter } from '../telemetry/telemetryRegistry.js';
 import { importMetricsToMemory, sanitizeMetricRecords } from './metricsService.js';
 import { gzipSync } from 'zlib';
 
@@ -185,5 +185,78 @@ export const importMetrics = async (req: Request, res: Response) => {
     } catch (err: any) {
         console.error('Import failed:', err);
         res.status(400).send({ error: 'Failed to import metrics', details: err.message });
+    }
+};
+
+export const getExportInterval = (req: Request, res: Response) => {
+    if (!mainMetricReader) {
+        res.status(400).send({ error: 'Metric reader not initialized' });
+        return;
+    }
+    res.send({ exportIntervalMillis: mainMetricReader.getInterval() });
+};
+
+export const setExportInterval = (req: Request, res: Response) => {
+    if (!mainMetricReader) {
+        res.status(400).send({ error: 'Metric reader not initialized' });
+        return;
+    }
+    const exportIntervalMillis = (req.body || {}).exportIntervalMillis;
+    if (typeof exportIntervalMillis !== 'number' || exportIntervalMillis <= 0) {
+        res.status(400).send({ error: 'Invalid export interval. Must be a positive number.' });
+        return;
+    }
+    mainMetricReader.setInterval(exportIntervalMillis);
+    res.send({ message: `Export interval set to ${exportIntervalMillis} milliseconds.`, exportIntervalMillis });
+};
+
+export const getIgnoredMetrics = (req: Request, res: Response) => {
+    if (!customFilterMetricExporter) {
+        res.status(400).send({ error: 'Filter exporter not initialized' });
+        return;
+    }
+    res.send({ ignoredMetrics: customFilterMetricExporter.getIgnoredMetrics() });
+};
+
+export const addIgnoredMetrics = (req: Request, res: Response) => {
+    if (!customFilterMetricExporter) {
+        res.status(400).send({ error: 'Filter exporter not initialized' });
+        return;
+    }
+    const { metric, metrics } = req.body || {};
+    if (metric) {
+        customFilterMetricExporter.addIgnoredMetric(metric);
+    }
+    if (Array.isArray(metrics)) {
+        customFilterMetricExporter.addIgnoredMetrics(metrics);
+    }
+    if (!metric && !Array.isArray(metrics)) {
+        res.status(400).send({ error: 'Provide a metric or metrics array in the body' });
+        return;
+    }
+    res.send({
+        message: 'Metrics added to ignore list',
+        ignoredMetrics: customFilterMetricExporter.getIgnoredMetrics()
+    });
+};
+
+export const removeIgnoredMetrics = (req: Request, res: Response) => {
+    if (!customFilterMetricExporter) {
+        res.status(400).send({ error: 'Filter exporter not initialized' });
+        return;
+    }
+    const metric = (req.body || {}).metric || (req.query || {}).metric;
+    if (metric) {
+        customFilterMetricExporter.removeIgnoredMetric(metric as string);
+        res.send({
+            message: `Metric '${metric}' removed from ignore list`,
+            ignoredMetrics: customFilterMetricExporter.getIgnoredMetrics()
+        });
+    } else {
+        customFilterMetricExporter.clearIgnoredMetrics();
+        res.send({
+            message: 'All metrics cleared from ignore list',
+            ignoredMetrics: []
+        });
     }
 };

--- a/packages/lib/src/tlm-metric/metricsRoutes.ts
+++ b/packages/lib/src/tlm-metric/metricsRoutes.ts
@@ -11,6 +11,11 @@ import {
     findMetrics,
     exportMetrics,
     importMetrics,
+    getExportInterval,
+    setExportInterval,
+    getIgnoredMetrics,
+    addIgnoredMetrics,
+    removeIgnoredMetrics,
 } from './metricsController.js';
 
 export const getMetricsRoutes = () => {
@@ -34,6 +39,13 @@ export const getMetricsRoutes = () => {
 
     router.post('/exporters/in-memory-exporter/data/find', findMetrics);
     router.get('/stats', getMetricsStats);
+
+    // Dynamic metrics endpoints
+    router.get('/export-interval', getExportInterval);
+    router.post('/export-interval', setExportInterval);
+    router.get('/ignored', getIgnoredMetrics);
+    router.post('/ignored', addIgnoredMetrics);
+    router.delete('/ignored', removeIgnoredMetrics);
 
     return router;
 };

--- a/packages/lib/test/e2e/definitions/metrics.ts
+++ b/packages/lib/test/e2e/definitions/metrics.ts
@@ -9,7 +9,7 @@ type Metric = { id?: string; name?: string };
 type MetricsResponse = { scopeMetrics: Metric[]; scopeMetricsCount: number };
 
 /*
-[!] IMPORTANT: 
+[!] IMPORTANT:
 If a test name contains `[!]`, it means that metrics are collected automatically every X milliseconds.
 This can affect test results, especially when expecting a precise count of metrics after a reset or insert operation.
 For example, even after a reset, the system may automatically export and insert 1 or 2 metrics before the test code executes.
@@ -340,6 +340,174 @@ export function defineMetricsApiTests(config: E2ETestConfig) {
             expect(singleResponse.data.scopeMetrics.length).toBe(1);
             expect(singleResponse.data.scopeMetrics[0].scope.name).toBe(firstMetric.scope.name);
             expect(singleResponse.data.scopeMetrics[0].descriptor.name).toBe(firstMetric.descriptor.name);
+        });
+
+        describe('Dynamic Metrics Configuration (Export Interval & Filtering)', () => {
+            const intervalUrl = `${metricsUrl}/export-interval`;
+            const ignoredUrl = `${metricsUrl}/ignored`;
+
+            it('[e2e][Metrics:Interval] should get and set the export interval', async () => {
+                const getRes = await axios.get(intervalUrl).catch((err) => err.response);
+                expect(getRes.status).toBe(200);
+                expect(getRes.data).toHaveProperty('exportIntervalMillis');
+                const originalInterval = getRes.data.exportIntervalMillis;
+
+                const setRes = await axios.post(intervalUrl, { exportIntervalMillis: 800 }).catch((err) => err.response);
+                expect(setRes.status).toBe(200);
+                expect(setRes.data.exportIntervalMillis).toBe(800);
+
+                const getRes2 = await axios.get(intervalUrl).catch((err) => err.response);
+                expect(getRes2.status).toBe(200);
+                expect(getRes2.data.exportIntervalMillis).toBe(800);
+
+                // Restore
+                await axios.post(intervalUrl, { exportIntervalMillis: originalInterval });
+            });
+
+            it('[e2e][Metrics:Interval] should reject invalid export intervals', async () => {
+                const setRes = await axios.post(intervalUrl, { exportIntervalMillis: -50 }).catch((err) => err.response);
+                expect(setRes.status).toBe(400);
+
+                const setRes2 = await axios.post(intervalUrl, { exportIntervalMillis: 'not-a-number' }).catch((err) => err.response);
+                expect(setRes2.status).toBe(400);
+            });
+
+            it('[e2e][Metrics:Filtering] should support adding, listing, removing and clearing ignored metrics', async () => {
+                // Clear initial
+                await axios.delete(ignoredUrl);
+
+                // Get initial empty list
+                const getRes = await axios.get(ignoredUrl).catch((err) => err.response);
+                expect(getRes.status).toBe(200);
+                expect(getRes.data.ignoredMetrics).toEqual([]);
+
+                // Add one metric
+                const addRes = await axios.post(ignoredUrl, { metric: 'ignored-scope-1' }).catch((err) => err.response);
+                expect(addRes.status).toBe(200);
+                expect(addRes.data.ignoredMetrics).toContain('ignored-scope-1');
+
+                // Add multiple metrics
+                const addMultiRes = await axios.post(ignoredUrl, { metrics: ['ignored-scope-2', 'ignored-scope-3'] }).catch((err) => err.response);
+                expect(addMultiRes.status).toBe(200);
+                expect(addMultiRes.data.ignoredMetrics).toContain('ignored-scope-2');
+                expect(addMultiRes.data.ignoredMetrics).toContain('ignored-scope-3');
+
+                // Get current list
+                const getRes2 = await axios.get(ignoredUrl).catch((err) => err.response);
+                expect(getRes2.data.ignoredMetrics).toEqual(
+                    expect.arrayContaining(['ignored-scope-1', 'ignored-scope-2', 'ignored-scope-3'])
+                );
+
+                // Remove one metric
+                const removeRes = await axios.delete(ignoredUrl, { data: { metric: 'ignored-scope-1' } }).catch((err) => err.response);
+                expect(removeRes.status).toBe(200);
+                expect(removeRes.data.ignoredMetrics).not.toContain('ignored-scope-1');
+
+                // Clear all metrics
+                const clearRes = await axios.delete(ignoredUrl).catch((err) => err.response);
+                expect(clearRes.status).toBe(200);
+                expect(clearRes.data.ignoredMetrics).toEqual([]);
+            });
+
+            it('[e2e][Metrics:Interval] should dynamically respect custom export intervals', async () => {
+                // Get original interval to restore it later
+                const getRes = await axios.get(intervalUrl);
+                const originalInterval = getRes.data.exportIntervalMillis;
+
+                // Clear in-memory database to start fresh
+                await axios.post(metricsResetUrl);
+
+                // Set a long export interval so it doesn't automatically export
+                await axios.post(intervalUrl, { exportIntervalMillis: 60000 });
+
+                // Reset the test exporter array
+                await axios.post(`${baseUrl}/test/exported-metrics/reset`);
+
+                // Wait a bit, record a metric by hitting /custom-metric
+                await axios.get(`${baseUrl}/custom-metric`);
+
+                // Wait 300 ms, check that it has NOT been exported yet to test exporter
+                await new Promise((resolve) => setTimeout(resolve, 300));
+                const checkRes1 = await axios.get(`${baseUrl}/test/exported-metrics`);
+                expect(checkRes1.data.count).toBe(0);
+
+                // Change interval to a very short one (100 ms)
+                await axios.post(intervalUrl, { exportIntervalMillis: 100 });
+
+                // Wait and verify it has now been exported to the test exporter
+                await retry(async () => {
+                    const checkRes2 = await axios.get(`${baseUrl}/test/exported-metrics`);
+                    expect(checkRes2.data.count).toBeGreaterThan(0);
+                }, { timeout: 1500, interval: 50 });
+
+                // Restore original interval
+                await axios.post(intervalUrl, { exportIntervalMillis: originalInterval });
+            });
+
+            it('[e2e][Metrics:Filtering] should filter out scope metrics from user defined exporter, but keep in in-memory DB', async () => {
+                // Clear ignored list
+                await axios.delete(ignoredUrl);
+
+                // Ignore 'PetClinic' scope
+                await axios.post(ignoredUrl, { metric: 'PetClinic' });
+
+                // Reset DB and test exporter
+                await axios.post(metricsResetUrl);
+                await axios.post(`${baseUrl}/test/exported-metrics/reset`);
+
+                // Set short interval to trigger export quickly
+                await axios.post(intervalUrl, { exportIntervalMillis: 100 });
+
+                // Let's hit /custom-metric to generate a 'PetClinic' metric
+                await axios.get(`${baseUrl}/custom-metric`);
+
+                // Let's wait for the export to occur (250 ms)
+                await new Promise((resolve) => setTimeout(resolve, 250));
+
+                // Check the in-memory DB: it should contain metrics from 'PetClinic' (since in-memory exporter is NOT filtered)
+                const dbRes = await axios.get<MetricsResponse>(metricsDataUrl);
+                const dbScopes = dbRes.data.scopeMetrics.map((sm) => sm.scope?.name);
+                expect(dbScopes).toContain('PetClinic');
+
+                // Check the TestExporter: it should NOT contain metrics from 'PetClinic' because it's ignored!
+                const exportRes = await axios.get(`${baseUrl}/test/exported-metrics`);
+                const exportedScopes: string[] = [];
+                exportRes.data.exported.forEach((rm: any) => {
+                    rm.scopeMetrics?.forEach((sm: any) => {
+                        if (sm.scope?.name) {
+                            exportedScopes.push(sm.scope.name);
+                        }
+                    });
+                });
+                expect(exportedScopes).not.toContain('PetClinic');
+
+                // Now remove 'PetClinic' from ignored list
+                await axios.delete(ignoredUrl, { data: { metric: 'PetClinic' } });
+
+                // Reset test exporter
+                await axios.post(`${baseUrl}/test/exported-metrics/reset`);
+
+                // Hit /custom-metric again
+                await axios.get(`${baseUrl}/custom-metric`);
+
+                // Wait and verify it is now exported to TestExporter!
+                await retry(async () => {
+                    const exportRes2 = await axios.get(`${baseUrl}/test/exported-metrics`);
+                    const exportedScopes2: string[] = [];
+                    exportRes2.data.exported.forEach((rm: any) => {
+                        rm.scopeMetrics?.forEach((sm: any) => {
+                            if (sm.scope?.name) {
+                                exportedScopes2.push(sm.scope.name);
+                            }
+                        });
+                    });
+                    expect(exportedScopes2).toContain('PetClinic');
+                }, { timeout: 1500, interval: 50 });
+
+                // Restore ignored list and default interval
+                await axios.delete(ignoredUrl);
+                await axios.post(intervalUrl, { exportIntervalMillis: 250 });
+            });
         });
     });
 }

--- a/packages/lib/test/e2e/servers/otTestServer.cjs
+++ b/packages/lib/test/e2e/servers/otTestServer.cjs
@@ -71,7 +71,34 @@ const spec = {
 }
 
 
-app.use(oasTelemetry({ general: { spec: JSON.stringify(spec) } }));
+class TestExporter {
+    static exported = [];
+    export(resourceMetrics, resultCallback) {
+        TestExporter.exported.push(JSON.parse(JSON.stringify(resourceMetrics)));
+        resultCallback({ code: 0 });
+    }
+    async shutdown() {}
+    async forceFlush() {}
+}
+
+app.use(oasTelemetry({
+    general: { spec: JSON.stringify(spec) },
+    metrics: {
+        extraExporters: [new TestExporter()]
+    }
+}));
+
+app.get('/test/exported-metrics', (req, res) => {
+    res.json({
+        exported: TestExporter.exported,
+        count: TestExporter.exported.length
+    });
+});
+
+app.post('/test/exported-metrics/reset', (req, res) => {
+    TestExporter.exported = [];
+    res.sendStatus(200);
+});
 
 const logger = logs.getLogger('PetClinic', '1.0.0');
 const meter = metrics.getMeter('PetClinic', '1.0.0');

--- a/packages/lib/test/e2e/servers/otTestServer.mjs
+++ b/packages/lib/test/e2e/servers/otTestServer.mjs
@@ -70,7 +70,34 @@ const spec = {
     }
 }
 
-app.use(oasTelemetry({ general: { spec: JSON.stringify(spec) } }));
+class TestExporter {
+    static exported = [];
+    export(resourceMetrics, resultCallback) {
+        TestExporter.exported.push(JSON.parse(JSON.stringify(resourceMetrics)));
+        resultCallback({ code: 0 });
+    }
+    async shutdown() {}
+    async forceFlush() {}
+}
+
+app.use(oasTelemetry({
+    general: { spec: JSON.stringify(spec) },
+    metrics: {
+        extraExporters: [new TestExporter()]
+    }
+}));
+
+app.get('/test/exported-metrics', (req, res) => {
+    res.json({
+        exported: TestExporter.exported,
+        count: TestExporter.exported.length
+    });
+});
+
+app.post('/test/exported-metrics/reset', (req, res) => {
+    TestExporter.exported = [];
+    res.sendStatus(200);
+});
 
 const logger = logs.getLogger('PetClinic', '1.0.0');
 const meter = metrics.getMeter('PetClinic', '1.0.0');

--- a/packages/lib/test/e2e/servers/otTestServer.ts
+++ b/packages/lib/test/e2e/servers/otTestServer.ts
@@ -79,6 +79,19 @@ const spec = {
     }
 }
 
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+import { ResourceMetrics } from '@opentelemetry/sdk-metrics';
+
+class TestExporter implements PushMetricExporter {
+    static exported: ResourceMetrics[] = [];
+    export(resourceMetrics: ResourceMetrics, resultCallback: (result: ExportResult) => void): void {
+        TestExporter.exported.push(JSON.parse(JSON.stringify(resourceMetrics))); // deep clone to avoid mutation issues
+        resultCallback({ code: ExportResultCode.SUCCESS });
+    }
+    async shutdown(): Promise<void> {}
+    async forceFlush(): Promise<void> {}
+}
+
 const oasTlmConfig: UserConfig = {
     general: {
         spec: JSON.stringify(spec),
@@ -91,10 +104,7 @@ const oasTlmConfig: UserConfig = {
         mainMetricReaderOptions: {
             exportIntervalMillis: 1000, // 5 seconds
         },
-        // extraReaders: [ new PeriodicExportingMetricReader( {
-        //     exportIntervalMillis: 1000 * 30, // 30 seconds
-        //     exporter: new ConsoleMetricExporter()
-        // })],
+        extraExporters: [new TestExporter()],
     },
     logs: {
         // extraExporters: [new ConsoleLogRecordExporter()],
@@ -121,6 +131,18 @@ const oasTlmConfig: UserConfig = {
 const telemetryRouter = oasTelemetry(oasTlmConfig);
 
 const app = express();
+
+app.get('/test/exported-metrics', (req, res) => {
+    res.json({
+        exported: TestExporter.exported,
+        count: TestExporter.exported.length
+    });
+});
+
+app.post('/test/exported-metrics/reset', (req, res) => {
+    TestExporter.exported = [];
+    res.sendStatus(200);
+});
 const port = process.env.PORT || 3000;
 
 


### PR DESCRIPTION
- Add metrics.extraExporters to userConfig. Following changes only apply to extraExporters, not extraReaders
- Add ignored metrics that do not get exported to userConfig defined
  exporters (they do get exported to user defined readers). Under POST/GET/DELETE /metrics/ignored
- Add dynamic exporting interval for userConfig defined exporters (it's
  ignored for user defined readers). Under GET/POST /metrics/export-interval

## Changes
- Added extraExporters as configuration. These changes do not apply to extraReaders
- The flow for extraExporters is DynamicPeriodicMetricReader -> FilterExporter -> MultiExporter -> extraExporters
- Added routes for configuration of the feature, including filtering of metrics (ignored metrics) and new dynamic interval

## Testing it out
- To run new tests do `npm run build` & `npm test`

To test it manually, run dev environment with `npm run dev`

### Dynamic intervals
- Get current export interval: `curl -X GET http://localhost:3000/oas-telemetry/metrics/export-interval`
- Update interval:
```bash
curl -X POST http://localhost:3000/oas-telemetry/metrics/export-interval \
		-H "Content-Type: application/json" \
		-d '{"exportIntervalMillis": 5000}'
```

### Metric filtering (ignored scope names)
- Get current ignore list: `curl -X GET http://localhost:3000/oas-telemetry/metrics/ignored`
- Adding scopes:
```bash
curl -X POST http://localhost:3000/oas-telemetry/metrics/ignored \
		-H "Content-Type: application/json" \
		-d '{"metrics": ["scope1", "scope2"]}'
```
- Removing specific scopes:
```bash
curl -X DELETE http://localhost:3000/oas-telemetry/metrics/ignored \
		-H "Content-Type: application/json" \
		-d '{"metric": "PetClinic"}'
```
- Clearing ignore list: `curl -X DELETE http://localhost:3000/oas-telemetry/metrics/ignored`