### PR TITLE
feat: change documentation url to docusaurus

### DIFF
--- a/packages/ui/src/components/pages/telemetry-header.tsx
+++ b/packages/ui/src/components/pages/telemetry-header.tsx
@@ -37,7 +37,7 @@ const tabs = [
 const usefulLinks = [
   {
     label: "Documentation",
-    href: "https://github.com/oas-tools/oas-telemetry",
+    href: "https://oas-telemetry.github.io/docusaurus/",
     icon: BookOpen
   },
   {


### PR DESCRIPTION
#### Description
Changed the documentation URL to the new docusaurus documentation

#### Implementation details
Changed the URL in the header link to documentation in the dashboard

#### Reproducing
Run `npm run dev`, open `http://localhost:5173/`, and click Useful Links > Documentation in the header navbar
